### PR TITLE
add environment hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,10 @@ install(TARGETS ${PROJECT_NAME}
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
 
+## install environment hook for gazebo plugin path
+# catkin_add_env_hooks (models_env SHELLS bash tcsh zsh DIRECTORY $ {CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+catkin_add_env_hooks (gz_plugins_env SHELLS bash DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env_hooks)
+
 #############
 ## Testing ##
 #############

--- a/env_hooks/gz_plugins_env.bash
+++ b/env_hooks/gz_plugins_env.bash
@@ -1,0 +1,2 @@
+#! /bin/bash
+export GAZEBO_PLUGIN_PATH="${GAZEBO_PLUGIN_PATH}:${CATKIN_ENV_HOOK_WORKSPACE}/devel"


### PR DESCRIPTION
This merge features the catkin environment hook that exports the GAZEBO_PLUGIN_PATH variable with the path of the compiled plugin.

This should resolve #1.